### PR TITLE
Add --persist=.xiphos to finish-args

### DIFF
--- a/org.xiphos.Xiphos.json
+++ b/org.xiphos.Xiphos.json
@@ -14,6 +14,7 @@
         /* Allow communication with network to get content */
         "--share=network",
         "--persist=.sword",
+        "--persist=.xiphos",
         "--talk-name=org.gnome.GConf"
     ],
     "cleanup": ["/include", "*.a", "*.la", "/lib/pkgconfig", "/share/gtk-doc", "/share/pkgconfig"],


### PR DESCRIPTION
Xiphos wants to save user settings in `~/.xiphos`, which it doesn't have access to. Running the app with this flag fixes the user settings issue. I'm new to Flatpak, but presumably putting the flag in `finish-args` like with `.sword` will do the same thing. Correct me if I'm wrong.

This should resolve #5 