### PR TITLE
Update runtime to 3.38

### DIFF
--- a/org.xiphos.Xiphos.json
+++ b/org.xiphos.Xiphos.json
@@ -1,7 +1,7 @@
 {
     "id": "org.xiphos.Xiphos",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.34",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "command": "xiphos",
     "rename-desktop-file": "xiphos.desktop",


### PR DESCRIPTION
Platform 3.34 is deprecated and causes font issues for me on Wayland. 3.38 is the newest that would build for me. I'm still trying to figure out why 40 and 41 fail to build.

This should resolve #7 